### PR TITLE
Add prev next buttons to page

### DIFF
--- a/content/posts/post-1.md
+++ b/content/posts/post-1.md
@@ -1,6 +1,6 @@
 ---
 title: "How to make toys from old Olarpaper"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T01:00:00Z
 image: /images/post/post-1.png
 categories: ["programming"]
 featured: true

--- a/content/posts/post-10.md
+++ b/content/posts/post-10.md
@@ -1,6 +1,6 @@
 ---
 title: "My work from home workstation"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T10:00:00Z
 image: /images/post/post-2.png
 categories: ["programming"]
 featured: false

--- a/content/posts/post-11.md
+++ b/content/posts/post-11.md
@@ -1,6 +1,6 @@
 ---
 title: "Robotic world is growing very fast"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T11:00:00Z
 image: /images/post/post-3.png
 categories: ["assistance"]
 featured: false

--- a/content/posts/post-12.md
+++ b/content/posts/post-12.md
@@ -1,6 +1,6 @@
 ---
 title: "What is a Virtual Assistant"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T12:00:00Z
 image: /images/post/post-4.png
 categories: ["github"]
 featured: true

--- a/content/posts/post-13.md
+++ b/content/posts/post-13.md
@@ -1,6 +1,6 @@
 ---
 title: "Why you need to learn PHP"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T13:00:00Z
 image: /images/post/post-5.png
 categories: ["youtube", "artificial-intelligence"]
 featured: false

--- a/content/posts/post-14.md
+++ b/content/posts/post-14.md
@@ -1,6 +1,6 @@
 ---
 title: "What you need to know about Programming"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T14:00:00Z
 image: /images/post/post-6.png
 categories: ["robotics", "youtube"]
 featured: false

--- a/content/posts/post-15.md
+++ b/content/posts/post-15.md
@@ -1,6 +1,6 @@
 ---
 title: "How to make toys from old Olarpaper"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T15:00:00Z
 image: /images/post/post-7.png
 categories: ["robotics", "assistance"]
 featured: false

--- a/content/posts/post-2.md
+++ b/content/posts/post-2.md
@@ -1,6 +1,6 @@
 ---
 title: My work from home workstation
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T02:00:00Z
 image: /images/post/post-2.png
 categories: ["drone"]
 featured: true

--- a/content/posts/post-3.md
+++ b/content/posts/post-3.md
@@ -1,6 +1,6 @@
 ---
 title: What you need to know about Photography
-date: 2022-04-02T06:00:00+00:00
+date: 2022-04-02T03:00:00+00:00
 image: /images/post/post-3.png
 categories: ["workstation"]
 featured: true

--- a/content/posts/post-4.md
+++ b/content/posts/post-4.md
@@ -1,6 +1,6 @@
 ---
 title: "How to make toys from old Olarpaper"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T04:00:00Z
 image: /images/post/post-4.png
 categories: ["robotics", "programming"]
 featured: false

--- a/content/posts/post-6.md
+++ b/content/posts/post-6.md
@@ -1,6 +1,6 @@
 ---
 title: "How to make toys from old Olarpaper"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T06:00:00Z
 image: /images/post/post-6.png
 categories: ["artificial-intelligence", "programming"]
 featured: true

--- a/content/posts/post-7.md
+++ b/content/posts/post-7.md
@@ -1,6 +1,6 @@
 ---
 title: "Artificial Intelligence and Robotics In A Nutshell"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T07:00:00Z
 image: /images/post/post-7.png
 categories: ["programming", "youtube"]
 featured: false

--- a/content/posts/post-8.md
+++ b/content/posts/post-8.md
@@ -1,6 +1,6 @@
 ---
 title: "Drone Software and Development"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T08:00:00Z
 image: /images/post/post-8.png
 categories: ["drone", "robotics"]
 featured: true

--- a/content/posts/post-9.md
+++ b/content/posts/post-9.md
@@ -1,6 +1,6 @@
 ---
 title: "Github Repository Controls"
-date: 2022-04-04T05:00:00Z
+date: 2022-04-04T09:00:00Z
 image: /images/post/post-1.png
 categories: ["workstation", "youtube"]
 featured: false

--- a/layouts/PostSingle.js
+++ b/layouts/PostSingle.js
@@ -7,6 +7,7 @@ import { MDXRemote } from "next-mdx-remote";
 import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
+import PrevNextNav from "@layouts/shortcodes/PrevNextNav";
 import { FaRegCalendar, FaUserAlt } from "react-icons/fa";
 import Post from "./partials/Post";
 import Sidebar from "./partials/Sidebar";
@@ -62,7 +63,8 @@ const PostSingle = ({
                     ))}
                   </ul>
                 </div>
-                {markdownify(title, "h1", "lg:text-[42px] mt-16")}
+                <PrevNextNav posts={posts} date={date}/>
+                {markdownify(title, "h1", "lg:text-[42px] mt-4")}
                 <ul className="flex items-center space-x-4">
                   <li>
                     <Link
@@ -81,6 +83,7 @@ const PostSingle = ({
                 <div className="content mb-16">
                   <MDXRemote {...mdxContent} components={shortcodes} />
                 </div>
+                <PrevNextNav posts={posts} date={date}/>
               </article>
               <div className="mt-16">
                 {disqus.enable && (

--- a/layouts/shortcodes/PrevNextNav.jsx
+++ b/layouts/shortcodes/PrevNextNav.jsx
@@ -1,0 +1,23 @@
+import Button from "@layouts/shortcodes/Button";
+import { sortByDate } from "@lib/utils/sortFunctions";
+import Link from "next/link";
+
+const PrevNextNav =({posts, date}) => {
+      const orderedPosts = sortByDate(posts);
+      const lastIndex = orderedPosts.length - 1;
+      const postIndex = orderedPosts.findIndex(post => post.frontmatter.date == date);
+      const next = postIndex == 0 ? undefined :         orderedPosts[postIndex-1].slug;
+      const prev = postIndex == lastIndex ? undefined : orderedPosts[postIndex+1].slug;
+      const prevButton = prev ? <Link href={prev} className={"block mx-2 inline-flex h-7 rounded-[35px] bg-primary px-3 text-white"}>Prev</Link> : '';
+      const nextButton = next ? <Link href={next} className={"block mx-2 inline-flex h-7 rounded-[35px] bg-primary px-3 text-white"}>Next</Link> : '';
+
+      return <div className="container mt-5">
+                        <div className="row">
+                            <span className="col">{prevButton}</span>
+                            <span className="col-8"/>
+                            <span className="col">{nextButton}</span>
+                        </div>
+                    </div>;
+};
+
+export default PrevNextNav;

--- a/pages/page/[slug].js
+++ b/pages/page/[slug].js
@@ -3,6 +3,7 @@ import Base from "@layouts/Baseof";
 import Pagination from "@layouts/components/Pagination";
 import { getListPage, getSinglePage } from "@lib/contentParser";
 import { markdownify } from "@lib/utils/textConverter";
+import { sortByDate } from "@lib/utils/sortFunctions";
 import Post from "@partials/Post";
 const { blog_folder, summary_length } = config.settings;
 
@@ -10,7 +11,7 @@ const { blog_folder, summary_length } = config.settings;
 const BlogPagination = ({ postIndex, posts, currentPage, pagination }) => {
   const indexOfLastPost = currentPage * pagination;
   const indexOfFirstPost = indexOfLastPost - pagination;
-  const orderedPosts = posts.sort((lhs, rhs) => rhs.frontmatter.date.localeCompare(lhs.frontmatter.date));
+  const orderedPosts = sortByDate(posts);
   const currentPosts = orderedPosts.slice(indexOfFirstPost, indexOfLastPost);
   const { frontmatter } = postIndex;
   const { title } = frontmatter;


### PR DESCRIPTION
The "Prev" button takes you to the chronologically prev article.
The "Next" button takes you to the chronologically next article.

Place the buttons at the top and bottom of every post.

Had to fix two things:
1: This [commit](https://github.com/statichunt/geeky-nextjs/pull/7/commits/03a35364b563955f9c51c2f7be135b46410f61c7) makes sure each article has a unique date.
2: Use the [filename (slug)](https://github.com/statichunt/geeky-nextjs/pull/7/commits/ffdbff27d954fd21eb2f835646dcd1dfddaf18fe#diff-fe313c6bf6624a043b6b0c816b617d55d00f5bae64612bf5b20989c79fdd2500R9-R10) rather than the title to create the link.
3: Rather than use a manual sort I have fixed to use the builtin sort: `lib/utils/sortFunctions`