### PR TITLE
Categories in post may by capitilized

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -13,6 +13,10 @@
     "theme_switcher": true,
     "default_theme": "system",
     "pagination": 6,
+    "InnerPaginationOptions": {
+        "enableTop": false,
+        "enableBot": true
+    },
     "summary_length": 200,
     "blog_folder": "posts"
   },

--- a/layouts/PostSingle.js
+++ b/layouts/PostSingle.js
@@ -68,6 +68,11 @@ const PostSingle = ({
                     ))}
                   </ul>
                 </div>
+                {config.settings.InnerPaginationOptions.enableTop && (
+                <div className="mt-4">
+                <InnerPagination posts={posts} date={date} />
+                </div>
+                )}
                 {markdownify(title, "h1", "lg:text-[42px] mt-4")}
                 <ul className="flex items-center space-x-4">
                   <li>
@@ -87,7 +92,9 @@ const PostSingle = ({
                 <div className="content mb-16">
                   <MDXRemote {...mdxContent} components={shortcodes} />
                 </div>
+                {config.settings.InnerPaginationOptions.enableBot && (
                 <InnerPagination posts={posts} date={date} />
+                )}
               </article>
               <div className="mt-16">
                 {disqus.enable && (

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -64,7 +64,7 @@ export const getStaticProps = ({ params }) => {
 
   const categoriesWithPostsCount = categories.map((category) => {
     const filteredPosts = posts.filter((post) =>
-      post.frontmatter.categories.includes(category)
+      post.frontmatter.categories.map(e => slugify(e)).includes(category)
     );
     return {
       name: category,

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -6,6 +6,7 @@ import Link from "next/link";
 const { blog_folder } = config.settings;
 import { getSinglePage } from "@lib/contentParser";
 import { FaFolder } from "react-icons/fa";
+import { slugify } from "@lib/utils/textConverter";
 
 const Categories = ({ categories }) => {
   return (
@@ -46,7 +47,7 @@ export const getStaticProps = () => {
   const categories = getTaxonomy(`content/${blog_folder}`, "categories");
   const categoriesWithPostsCount = categories.map((category) => {
     const filteredPosts = posts.filter((post) =>
-      post.frontmatter.categories.includes(category)
+      post.frontmatter.categories.map(e => slugify(e)).includes(category)
     );
     return {
       name: category,


### PR DESCRIPTION
Built on top of https://github.com/statichunt/geeky-nextjs/pull/10

Needed to make sure categories extracted from a post are slugified so they can be compared.
Only change: https://github.com/statichunt/geeky-nextjs/pull/11/commits/1a8826de737bfc160d5bf2e15ae96ab03e85b7ae