### PR TITLE
fix: running npm export directly will need to generate json too

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node lib/jsonGenerator.js && next dev",
     "build": "node lib/jsonGenerator.js && next build",
-    "export": "next build && next export",
+    "export": "npm run build && next build && next export",
     "lint": "next lint",
     "start": "next start"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node lib/jsonGenerator.js && next dev",
     "build": "node lib/jsonGenerator.js && next build",
-    "export": "npm run build && next build && next export",
+    "export": "npm run build && next export",
     "lint": "next lint",
     "start": "next start"
   },


### PR DESCRIPTION
run `npm run build` before export or `node lib/jsonGenerator.js && next build` to generate json files for static build directly